### PR TITLE
Make getBestSense() work with negative scores

### DIFF
--- a/de.tudarmstadt.ukp.dkpro.wsd.core/src/main/java/de/tudarmstadt/ukp/dkpro/wsd/type/WSDResult.java
+++ b/de.tudarmstadt.ukp.dkpro.wsd.core/src/main/java/de/tudarmstadt/ukp/dkpro/wsd/type/WSDResult.java
@@ -270,7 +270,7 @@ extends Annotation
 	 * Returns the sense with the highest score (returns first one if multiple exist)
 	 */
 	public Sense getBestSense(){
-		double highestConfidence = 0.0;
+		double highestConfidence = Double.NEGATIVE_INFINITY;
 		int numSenses = getSenses().size();
 		Sense bestSense = null;
 


### PR DESCRIPTION
getBestSense() returns null if all "confidence" scores are negative. I ran into this issue when working with a system that outputs scores from -inf to inf and it took a while to track down the cause of the null pointer exceptions.