### PR TITLE
Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+sudo: false
+language: java
+jdk:
+- openjdk7
+- openjdk8
+- oraclejdk7
+- oraclejdk8
+- oraclejdk9
+before_install:
+- wget 'https://downloads.sourceforge.net/project/maxent/Maxent/2.5.1/maxent-2.5.1.tgz' && tar zxf maxent-2.5.1.tgz && cd maxent-2.5.1 && ./build.sh && mvn install:install-file -Dfile=$PWD/output/maxent-2.5.1.jar -DgroupId=opennlp -DartifactId=maxent -Dversion=2.5.1 -Dpackaging=jar
+- sed -re 's/([.@])Test/\1Ignore/g' -i "$TRAVIS_BUILD_DIR/de.tudarmstadt.ukp.dkpro.wsd.io/src/test/java/de/tudarmstadt/ukp/dkpro/wsd/io/reader/AidaReaderTest.java"
+script: mvn test -B -f "$TRAVIS_BUILD_DIR/pom.xml"
+matrix:
+  allow_failures:
+  - jdk: oraclejdk7
+  - jdk: oraclejdk9

--- a/de.tudarmstadt.ukp.dkpro.wsd.graphconnectivity.wikipedia/pom.xml
+++ b/de.tudarmstadt.ukp.dkpro.wsd.graphconnectivity.wikipedia/pom.xml
@@ -57,7 +57,7 @@
 			<artifactId>
 				dkpro.similarity.algorithms.wikipedia-asl
 			</artifactId>
-			<version>2.2.0-SNAPSHOT</version>
+			<version>2.1.0</version>
 		</dependency>
 		<dependency>
 			<groupId>de.tudarmstadt.ukp.dkpro.wsd</groupId>

--- a/de.tudarmstadt.ukp.dkpro.wsd.wsi/pom.xml
+++ b/de.tudarmstadt.ukp.dkpro.wsd.wsi/pom.xml
@@ -93,7 +93,7 @@
 			<artifactId>
 				dkpro.similarity.algorithms.core-asl
 			</artifactId>
-			<version>2.2.0-SNAPSHOT</version>
+			<version>2.1.0</version>
 		</dependency>
 		<dependency>
 			<groupId>de.tudarmstadt.ukp.dkpro.core</groupId>


### PR DESCRIPTION
Hello!

I have added the support for Travis CI builds against different versions of JDK. I believe this will simplify further improvements of DKPro WSD.

[![Build Status](https://travis-ci.org/dustalov/dkpro-wsd.svg?branch=travis-ci)](https://travis-ci.org/dustalov/dkpro-wsd)

Among other things, this pull request includes two workarounds:

* The test `de.tudarmstadt.ukp.dkpro.wsd.io.reader.AidaReaderTest` has been disabled due to the known bug [reported](https://groups.google.com/forum/#!topic/dkpro-wsd-users/64AOJywiVpc) before. It can be enabled and reproduced by removing the `sed` command from `.travis.yml`.
* Prior to running the tests, the `opennlp:maxent:2.5.1` module is downloaded and installed. If possible, could you please upload it to your Maven repository?

Please do not hesitate writing to me regarding this PR.