### PR TITLE
small changes to solve some small issues

### DIFF
--- a/de.tudarmstadt.ukp.dkpro.wsd.core/src/main/java/de/tudarmstadt/ukp/dkpro/wsd/annotator/WSDAnnotatorBase.java
+++ b/de.tudarmstadt.ukp.dkpro.wsd.core/src/main/java/de/tudarmstadt/ukp/dkpro/wsd/annotator/WSDAnnotatorBase.java
@@ -136,7 +136,9 @@ public abstract class WSDAnnotatorBase
             wsdResult.setSenseInventory(inventory.getSenseInventoryName());
             wsdResult.setDisambiguationMethod(getDisambiguationMethod());
             wsdResult.setWsdItem(wsdItem);
-
+            wsdResult.setBegin(wsdItem.getBegin());
+            wsdResult.setEnd(wsdItem.getEnd());
+            
             if (bestOnly == true) {
                 discardAllButHighestConfidence(disambiguationResult);
                 if (tieStrategy == TieStrategy.FAIL

--- a/de.tudarmstadt.ukp.dkpro.wsd.core/src/main/java/de/tudarmstadt/ukp/dkpro/wsd/annotator/WSDAnnotatorContextPOS.java
+++ b/de.tudarmstadt.ukp.dkpro.wsd.core/src/main/java/de/tudarmstadt/ukp/dkpro/wsd/annotator/WSDAnnotatorContextPOS.java
@@ -61,9 +61,18 @@ public class WSDAnnotatorContextPOS
         // TODO: Currently this just passes the covered text as the context.
         // It might be better to pass a collection of annotations (for example,
         // lemmas)
-        return wsdMethod.getDisambiguation(
-                wsdItem.getSubjectOfDisambiguation(),
-                POS.valueOf(wsdItem.getPos()), context.getCoveredText());
+    	try {
+    		return wsdMethod.getDisambiguation(
+    				wsdItem.getSubjectOfDisambiguation(),
+    				POS.valueOf(wsdItem.getPos()), context.getCoveredText());
+
+    	} catch (Exception e){
+    	    // System.out.println("Exception " + wsdItem.getCoveredText()+ "--"+ wsdItem.getPos());
+    		// as pos is unknown use NOUN, or try it with null... 
+    	    return wsdMethod.getDisambiguation(wsdItem.getSubjectOfDisambiguation(),POS.NOUN,context.getCoveredText()); 
+        	// or  throw exception 
+        	// throw e;
+        }
     }
 
     @Override


### PR DESCRIPTION
no begin/end in wsdresult
crash when no POS (This happens in multiwords) for WSDAnnotatorContextPOS
-The current option is to set up NOUN as default POS 
- the other one is to generate an exception with a clear message
- another option is to create a method that does the same as   WSDAnnotatorContextBase (with no pos) and  call it when pos is not available.