### PR TITLE
SI multilingual

### DIFF
--- a/de.tudarmstadt.ukp.dkpro.wsd.core/src/main/java/de/tudarmstadt/ukp/dkpro/wsd/annotator/WSDAnnotatorBase.java
+++ b/de.tudarmstadt.ukp.dkpro.wsd.core/src/main/java/de/tudarmstadt/ukp/dkpro/wsd/annotator/WSDAnnotatorBase.java
@@ -177,7 +177,7 @@ public abstract class WSDAnnotatorBase
                 sense.setConfidence(entry.getValue());
                 if (setSenseDescriptions == true) {
                     sense.setDescription(inventory.getSenseDescription(entry
-                            .getKey()));
+                            .getKey(),true));
                 }
                 // TODO: Is it really necessary to add senses to the indexes?
                 sense.addToIndexes();

--- a/de.tudarmstadt.ukp.dkpro.wsd.core/src/main/java/de/tudarmstadt/ukp/dkpro/wsd/si/SenseInventory.java
+++ b/de.tudarmstadt.ukp.dkpro.wsd.core/src/main/java/de/tudarmstadt/ukp/dkpro/wsd/si/SenseInventory.java
@@ -107,7 +107,17 @@ public interface SenseInventory
      */
     String getSenseDescription(String senseId)
         throws SenseInventoryException;
-
+    /**
+     * @param senseId
+     * @return A human readable description of the current sense represented by
+     *         its senseId or an empty string if no description is available. A
+     *         {@link SenseInventoryException} is thrown if the senseId is
+     *         invalid.
+     * @throws SenseInventoryException
+     */
+    String getSenseDescription(String senseId,boolean seclang)
+        throws SenseInventoryException;
+    
     /**
      * @param senseId
      * @return The part of speech of the sense represented by the given senseId.

--- a/de.tudarmstadt.ukp.dkpro.wsd.core/src/main/java/de/tudarmstadt/ukp/dkpro/wsd/si/SenseInventoryBase.java
+++ b/de.tudarmstadt.ukp.dkpro.wsd.core/src/main/java/de/tudarmstadt/ukp/dkpro/wsd/si/SenseInventoryBase.java
@@ -70,4 +70,12 @@ public abstract class SenseInventoryBase
         }
         return mostFrequentSense;
     }
+    
+    @Override
+    public String getSenseDescription(String senseId,boolean seclang)
+        throws SenseInventoryException
+    {
+    	return  getSenseDescription(senseId);
+    }
+    
 }

--- a/de.tudarmstadt.ukp.dkpro.wsd.core/src/main/java/de/tudarmstadt/ukp/dkpro/wsd/si/resource/SenseInventoryResourceBase.java
+++ b/de.tudarmstadt.ukp.dkpro.wsd.core/src/main/java/de/tudarmstadt/ukp/dkpro/wsd/si/resource/SenseInventoryResourceBase.java
@@ -161,6 +161,13 @@ public abstract class SenseInventoryResourceBase
     }
 
     @Override
+    public String getSenseDescription(String senseId, boolean lang)
+    	throws SenseInventoryException
+    {
+    	return inventory.getSenseDescription(senseId,lang);
+    }
+    
+    @Override
     public POS getPos(String senseId)
         throws SenseInventoryException
     {


### PR DESCRIPTION
It allows to get the description of the synset in a different language
than the one used for disambiguation (the one of the text) useful for
translation or help to understand the text